### PR TITLE
patch 2016 bin labels

### DIFF
--- a/src/hps_align/plot/_plotter.py
+++ b/src/hps_align/plot/_plotter.py
@@ -424,12 +424,12 @@ class Plotter:
         plotProperties = []
 
         for ihisto in range(len(histos)):
-            self.set_histo_style(histos[ihisto], ihisto, line_width=3)
 
             # Scale the histogram to unity
             if scale_histos:
                 histos[ihisto].Scale(1./histos[ihisto].Integral())
-            histos[ihisto].SetLineWidth(3)
+
+            self.set_histo_style(histos[ihisto], ihisto, line_width=3)
 
             if fit or isinstance(fit, dict):
                 fitting_kwargs = dict(

--- a/src/hps_align/plot/_plotter.py
+++ b/src/hps_align/plot/_plotter.py
@@ -84,15 +84,33 @@ class Plotter:
                         r.kFullCircle, r.kOpenSquare, r.kFullSquare,
                         r.kOpenTriangleUp, r.kOpenCircle, r.kFullCircle,
                         r.kOpenSquare, r.kFullSquare, r.kOpenTriangleUp]
-        # bin labels for kink and ures summary plots
-        self.binLabels = ["", "L1tA", "L1tS", "L2tA", "L2tS", "L3tA", "L3tS",
-                          "L4tA", "L4tS", "L5tAh", "L5tSh", "L5tAs", "L5tSs",
-                          "L6tAh", "L6tSh", "L6tAs", "L6tSs", "L7tAh", "L7tSh",
-                          "L7tAs", "L7tSs", "", "", "", "", "", "L1bA", "L1bS",
-                          "L2bA", "L2bS", "L3bA", "L3bS", "L4bA", "L4bS",
-                          "L5bAh", "L5bSh", "L5bAs", "L5bSs", "L6bAh",
-                          "L6bSh", "L6bAs", "L6bSs", "L7bAh", "L7bSh",
-                          "L7bAs", "L7bSs", "", "", "", "", "", "", "", "", "", "", "", ""]
+        # bin labels for per-sensor summary plots (e.g. kink and ures)
+        if is2016:
+            self.binLabels = ["",
+                              "L1tA", "L1tS", "L2tA", "L2tS", "L3tA", "L3tS",
+                              "L4tAh", "L4tSh", "L4tAs", "L4tSs",
+                              "L5tAh", "L5tSh", "L5tAs", "L5tSs",
+                              "L6tAh", "L6tSh", "L6tAs", "L6tSs",
+                              "", "", "", "", "",
+                              "L1bA", "L1bS", "L2bA", "L2bS", "L3bA", "L3bS",
+                              "L4bAh", "L4bSh", "L4bAs", "L4bSs",
+                              "L5bAh", "L5bSh", "L5bAs", "L5bSs",
+                              "L6bAh", "L6bSh", "L6bAs", "L6bSs",
+                              "", "", "", "", "", "", "", "", "", "", "", ""]
+        else:
+            self.binLabels = ["",
+                              "L1tA", "L1tS", "L2tA", "L2tS",
+                              "L3tA", "L3tS", "L4tA", "L4tS",
+                              "L5tAh", "L5tSh", "L5tAs", "L5tSs",
+                              "L6tAh", "L6tSh", "L6tAs", "L6tSs",
+                              "L7tAh", "L7tSh", "L7tAs", "L7tSs",
+                              "", "", "", "", "",
+                              "L1bA", "L1bS", "L2bA", "L2bS",
+                              "L3bA", "L3bS", "L4bA", "L4bS",
+                              "L5bAh", "L5bSh", "L5bAs", "L5bSs",
+                              "L6bAh", "L6bSh", "L6bAs", "L6bSs",
+                              "L7bAh", "L7bSh", "L7bAs", "L7bSs",
+                              "", "", "", "", "", "", "", "", "", "", "", ""]
 
         self.legend_names = legend_names
         self.infile_names = infile_names

--- a/src/hps_align/plot/alignment_utils.py
+++ b/src/hps_align/plot/alignment_utils.py
@@ -205,13 +205,12 @@ def single_gauss_iterative(hist, sigmaRange, range=[], color=None):
             print("i = ", i, " newFitMean = ",
                   newFitMean, " newFitSig = ", newFitSig)
         if (i > 50):
-            if debug:
-                print(
-                    "WARNING terminate iterative gaus fit because of convergence problems")
-                print("final mean =  ", newFitMean,
-                      ", previous iter mean = ", fitMean)
-                print("final sigma =  ", newFitSig,
-                      ", previous iter sigma = ", fitSig)
+            print(
+                "WARNING terminate iterative gaus fit because of convergence problems")
+            print("final mean =  ", newFitMean,
+                  ", previous iter mean = ", fitMean)
+            print("final sigma =  ", newFitSig,
+                  ", previous iter sigma = ", fitSig)
             break
 
         i += 1

--- a/src/hps_align/plot/residual.py
+++ b/src/hps_align/plot/residual.py
@@ -94,6 +94,11 @@ def vs_u(p: Plotter):
         names = p.plot_list('ures_vs_u_plots')[vol]['name']
         titles = p.plot_list('ures_vs_u_plots')[vol]['title']
         for ipl, (name, title) in enumerate(zip(names, titles)):
+            # rangeX is u measurement and changes depending on
+            #    year and orientation (Ax/St and H/S for back) of sensor
+            # we could implement a method for deducing where to "zoom"
+            #   in for the different sensors here since all the plots have
+            #   a half-empty canvas (which half changes)
             p.plot_profileY(
                 name, xtitle=title,
                 indir='res/',


### PR DESCRIPTION
The main purpose of this PR is to support the correct per-sensor bin labeling for 2016 without breaking the current labeling for 2019/21. I also have a few other small patches that I am less committed to so if there is any reason to not implement these other patches I would be happy to drop them.

- support both 2016 and 2019/21 per-sensor bin labeling
- do styling after scaling to avoid style-reset
- comment about how we could use rangeX in the ures_vs_u plots
- always print the failure-to-fit warning despite debug status
