### PR TITLE
plot detdump data

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ since it relies more on the filesystem, but it is
 operational.
 ```
 # install dependencies
-python3 -m pip install --user typer[all]
+python3 -m pip install --user typer[all] matplotlib pandas
 # "install" this package "manually"
 ln -s $(realpath src/hps_align) ~/.local/lib/python3.6/site-packages/
 ```

--- a/docs/hps_align.detdump.rst
+++ b/docs/hps_align.detdump.rst
@@ -41,6 +41,13 @@ or relative to a certain reference detector.
    :private-members:
 
 
+Calculating Angles
+^^^^^^^^^^^^^^^^^^
+
+.. automodule:: hps_align.detdump.plot._angles
+   :members:
+   :private-members:
+
 Loading Dumps
 ^^^^^^^^^^^^^
 Loading the dumps gives us an opportunity to apply transformations

--- a/docs/hps_align.detdump.rst
+++ b/docs/hps_align.detdump.rst
@@ -29,3 +29,36 @@ into a more easily-parsed format (either CSV or JSON).
 .. automodule:: hps_align.detdump._write
    :members:
    :private-members:
+
+Plotting
+--------
+We can also summarize the dumped detector parameters through
+plots showing the sensor location/orientation in absolute terms
+or relative to a certain reference detector.
+
+.. automodule:: hps_align.detdump.plot
+   :members:
+   :private-members:
+
+
+Loading Dumps
+^^^^^^^^^^^^^
+Loading the dumps gives us an opportunity to apply transformations
+to the coordinate vectors and positions so that the values we look
+at in the plots are more interpretable by the user. For example,
+This is where we choose how to calculate angles from the coordinate
+vectors u, v, and w.
+
+.. automodule:: hps_align.detdump.plot._load
+   :members:
+   :private-members:
+
+Table of Figures
+^^^^^^^^^^^^^^^^
+We've isolated the matplotlib nonsense for putting together
+several figures into a "table" of subplots so that it is easier
+to maintain. This is where stylistic choices are made.
+
+.. automodule:: hps_align.detdump.plot._table_fig
+   :members:
+   :private-members:

--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,8 @@ setup(
     # https://packaging.python.org/discussions/install-requires-vs-requirements/
     install_requires=[
         "typer[all]",
+        "matplotlib",
+        "pandas"
     ],
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/src/hps_align/detdump/__init__.py
+++ b/src/hps_align/detdump/__init__.py
@@ -3,3 +3,11 @@
 from . import _global
 from . import _local
 from ._cli import app
+
+from . import plot
+
+app.add_typer(
+    plot.app,
+    name="plot",
+    help=plot.__doc__
+    )

--- a/src/hps_align/detdump/__init__.py
+++ b/src/hps_align/detdump/__init__.py
@@ -10,4 +10,4 @@ app.add_typer(
     plot.app,
     name="plot",
     help=plot.__doc__
-    )
+)

--- a/src/hps_align/detdump/__init__.py
+++ b/src/hps_align/detdump/__init__.py
@@ -5,9 +5,3 @@ from . import _local
 from ._cli import app
 
 from . import plot
-
-app.add_typer(
-    plot.app,
-    name="plot",
-    help=plot.__doc__
-)

--- a/src/hps_align/detdump/_global.py
+++ b/src/hps_align/detdump/_global.py
@@ -4,7 +4,7 @@ import typer
 from pathlib import Path
 import subprocess
 import os
-from ._write import OutputType, write_mapping
+from ._write import write_mapping
 from ._cli import app
 
 
@@ -31,10 +31,7 @@ def global_coord(
          'hps-distribution' / '5.2-SNAPSHOT' / 'hps-distribution-5.2-SNAPSHOT-bin.jar'),
         help='java bin jar to use to run geometry printer'
     ),
-    output_file: str = typer.Option(None, help='output file to write data to, uses detector name by default'),
-    output_type: OutputType = typer.Option(
-        'json',
-        help='type of output to write will be over-written by extension of output_file if provided')
+    output_file: str = typer.Option(None, help='output file to write data to, uses detector name by default')
 ):
     """dump coordinates of sensors in global frame
 
@@ -57,30 +54,8 @@ def global_coord(
     Since the 2019 and 2021 conditions have the same "shape", we can use
     the same (somewhat arbitrary) run number if desired.
 
-    User
-    ----
-
-    bin.jar file
-        the PrintGeometryDriver has been on
-        hps-java master for awhile so this does not need to
-        be incredibly recent.
-
-    input slcio file
-        the driver does not look at any
-        of the events in the slcio file so it just needs to
-        be /any/ slcio file with at least one event in it.
-
-    detname
-        name of detector
-
-    run number
-        the run number needs to be a valid run number for that year
-        so that hps-java can pull down condition
-        databases, but it doesn't need to pertain to the
-        detector being used
-
-    Auto
-    ----
+    Auto-Deduced java Arguments
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     java args
         we aren't doing any strong processing or using GBL
@@ -94,18 +69,36 @@ def global_coord(
 
     number of events
         we just need one to trigger the functionality of loading the detector
+
+    Parameters
+    ----------
+
+    detname : str
+        The name of the detector to load
+    input_file : Path
+        the driver does not look at any
+        of the events in the slcio file so it just needs to
+        be /any/ slcio file with at least one event in it.
+    run_number : int
+        The run number needs to be a valid run number for that year
+        so that hps-java can pull down condition
+        databases, but it doesn't need to pertain to the
+        detector being used
+    jar : Path, optional
+        the PrintGeometryDriver has been on
+        hps-java master for awhile so this does not need to
+        be incredibly recent. The default is the path to the 5.2-SNAPSHOT
+        located in the user's home maven repository.
+
     """
 
     if output_file is None:
         # deduce default to be name of detector + extension
-        output_file = f'{detname}-local.{output_type.value}'
+        output_file = f'{detname}-global.csv'
 
     if Path(output_file).suffix == '':
-        # no extension provided, use output_type
-        output_file += '.'+output_type.value
-
-    if not OutputType.valid(Path(output_file)):
-        raise ValueError(f'{output_file} does not have one of the allowed extensions')
+        # no extension provided, add it manually
+        output_file += '.csv'
 
     geo_print_result = subprocess.run(
         [
@@ -157,8 +150,8 @@ def global_coord(
 
     write_mapping(output_file, sensor_map,
                   header=['sensor',
-                          'hpsX', 'hpsY', 'hpsZ',
-                          'svtX', 'svtY', 'svtZ',
+                          'hpsx', 'hpsy', 'hpsz',
+                          'svtx', 'svty', 'svtz',
                           'ux', 'uy', 'uz',
                           'vx', 'vy', 'vz',
                           'wx', 'wy', 'wz'],

--- a/src/hps_align/detdump/_local.py
+++ b/src/hps_align/detdump/_local.py
@@ -3,7 +3,7 @@ import typer
 
 from pathlib import Path
 import xml.etree.ElementTree as ET
-from ._write import OutputType, write_mapping
+from ._write import write_mapping
 from ._cli import app
 
 
@@ -17,10 +17,7 @@ the local coordinate frame and so they are kind of the
 )
 def local_coord(
     detpath: Path = typer.Argument(..., help='path to detector to dump'),
-    output_file: str = typer.Option(None, help='output file to write data to, uses detector name by default'),
-    output_type: OutputType = typer.Option(
-        'json',
-        help='type of output to write will be over-written by extension of output_file if provided')
+    output_file: str = typer.Option(None, help='output file to write data to, uses detector name by default')
 ):
     """dump coordinates in local frame
 
@@ -38,14 +35,11 @@ def local_coord(
 
     if output_file is None:
         # deduce default to be name of detector + extension
-        output_file = f'{detpath.parts[-1]}-local.{output_type.value}'
+        output_file = f'{detpath.parts[-1]}-local.csv'
 
     if Path(output_file).suffix == '':
-        # no extension provided, use output_type
-        output_file += '.'+output_type.value
-
-    if not OutputType.valid(Path(output_file)):
-        raise ValueError(f'{output_file} does not have one of the allowed extensions')
+        # no extension provided, add it manually
+        output_file += '.csv'
 
     tree = ET.parse(detpath / 'compact.xml')
 

--- a/src/hps_align/detdump/_write.py
+++ b/src/hps_align/detdump/_write.py
@@ -5,32 +5,6 @@ import json
 import csv
 
 
-class OutputType(Enum):
-    CSV = "csv"
-    JSON = "json"
-
-    def valid(p: Path):
-        """validate that the input path is one of our types
-
-        We check validity by making sure the extension of the passed
-        Path is one of the supported output types in this Enum.
-
-        Parameters
-        ----------
-        p : Path
-            path to file to check output type of
-
-        Returns
-        -------
-        bool :
-            True if valid, False otherwise
-        """
-
-        if p.suffix not in ['.'+e.value for e in OutputType.__members__.values()]:
-            return False
-        return True
-
-
 def __get_row_default(k, v):
     """default implementation of getrow"""
     return [str(k), str(v)]
@@ -50,20 +24,13 @@ def write_mapping(output_file, data, *, header=None, getrow=__get_row_default):
         list of header rows to write to csv
         no header written if not provided
     getrow: callable
-        produce a row given a key, val pair from the mapping as arguments
-        default is to just write the key and value as two columns
+        produce a row given a key, val pair from the mapping as arguments.
+        The default is to just write the key and value as two columns
+        :meth:`__get_row_default`
     """
-    if output_file.endswith('csv'):
-        if getrow is None:
-            raise ValueError('getrow necessary if attempting to write to CSV')
-        with open(output_file, 'w', newline='') as csvfile:
-            csvwriter = csv.writer(csvfile)
-            if header is not None:
-                csvwriter.writerow(header)
-            for name, val in data.items():
-                csvwriter.writerow(getrow(name, val))
-    elif output_file.endswith('json'):
-        with open(output_file, 'w', encoding='utf-8') as f:
-            json.dump(data, f, indent=4)
-    else:
-        raise ValueError(f'Unable to deduce output type from extension of {output_file}')
+    with open(output_file, 'w', newline='') as csvfile:
+        csvwriter = csv.writer(csvfile)
+        if header is not None:
+            csvwriter.writerow(header)
+        for name, val in data.items():
+            csvwriter.writerow(getrow(name, val))

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -65,8 +65,15 @@ def diff(
     out: Path = typer.Option("diff.pdf", help="output file name to print image to"),
     which: str = typer.Option("hps", help="Which global coordinate system to use ('hps' or 'svt')")
 ):
+    """Plot difference between detectors and a reference detector.
+
+    The reference detector is the first detector provided in the input list.
+    All detectors are named after the name of the file. Use soft links to
+    rename files to helpful legend names if you wish.
+    """
+
     if local:
-        raise ValueError('local plot not implemented yet')
+        raise ValueError('local plotting not implemented yet')
 
     data = [
         (inf.stem, _load.glbl(inf).set_index(["sensor"]))
@@ -95,8 +102,14 @@ def abs(
     out: Path = typer.Option("abs.pdf", help="output file name to print image to"),
     which: str = typer.Option("hps", help="Which global coordinate system to use ('hps' or 'svt')")
 ):
+    """Plot the absolute position, overlaying all provided detectors
+
+    All detectors are named after the name of the provided file. Use soft links `ln -s` to
+    rename files to helpful legend names if you wish.
+    """
+
     if local:
-        raise ValueError('local plot not implemented yet')
+        raise ValueError('local plotting not implemented yet')
 
     data = [
         (inf.stem, _load.glbl(inf))

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -122,10 +122,8 @@ def plot(
             for name, df in data[1:]
         ]
         # remove layers not in both years if comparing both detector versions
-        if any(years) and not all(years) and years[0]:
-            data = [(name, df[df.lay > 2.5]) for name, df in data]
-        if any(years) and not all(years) and not years[0]:
-            data = [(name, df[df.lay > 1.5]) for name, df in data]
+        if any(years) and not all(years):
+            data = [((name, df[df.lay > 1.5]) if (df['lay'] == 1.0).any() else (name, df[df.lay > 2.5])) for name, df in data]
         # change plot title
         plot_kw['title'] = f'Difference Relative to {ref_name}'
 

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -114,11 +114,18 @@ def plot(
             df.set_index([index], inplace=True)
         # get reference detector
         ref_name, ref_table = data[0]
+        ref_table['sortval'] = 0
+        ref_table['lay'] = 0
         # subtract away the first detector provided
         data = [
-            (name, (df-ref_table).reset_index())
+            (name, (df-ref_table).reset_index().sort_values('sortval').dropna(subset = ['ux']).reset_index(drop=True))
             for name, df in data[1:]
         ]
+        # remove layers not in both years if comparing both detector versions
+        if any(years) and not all(years) and years[0]:
+            data = [ (name, df[df.lay > 2.5]) for name, df in data ]
+        if any(years) and not all(years) and not years[0]:
+            data = [ (name, df[df.lay > 1.5]) for name, df in data ]
         # change plot title
         plot_kw['title'] = f'Difference Relative to {ref_name}'
 

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -68,6 +68,8 @@ def plot(
 
     if coord == Coord.LOCAL:
         from ._load import _local as loader
+        from ._load import _local_is2016 as is2016
+        from ._load import _local_remap2016 as remap2016
         from ._table_fig import _local as plotter
         index = 'parameter'
         plot_kw = dict()
@@ -76,16 +78,18 @@ def plot(
             plot_kw['title'] = 'Constant Values'
     else:
         from ._load import _global as loader
+        from ._load import _global_is2016 as is2016
+        from ._load import _global_remap2016 as remap2016
         from ._table_fig import _global as plotter
         index = 'sensor'
         angle_def = angle_calculator.__registry__[angle.value]
         plot_kw = dict(
             position=pos.value,
             angle_title=angle_def.__title__
-            )
+        )
         load_kw = dict(
             angle_calculator=angle_def
-            )
+        )
         if plot == Plot.ABS:
             plot_kw['title'] = 'Absolute Position and Orientation'
 
@@ -93,6 +97,14 @@ def plot(
         (inf.stem, loader(inf, **load_kw))
         for inf in input_file
     ]
+
+    years = [is2016(df) for _name, df in data]
+    if any(years) and not all(years):
+        # at least one is 2016 but not all of them,
+        # apply 2016 remap to the 2016 ones
+        for yes2016, (_name, df) in zip(years, data):
+            if yes2016:
+                df[index] = df[index].apply(lambda i: remap2016[i])
 
     if plot == Plot.DIFF:
         if len(data) < 2:

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -2,17 +2,25 @@
 
 from typing import List
 from pathlib import Path
+from enum import Enum
 
 import typer
 
 from ._cli import app
 
+
+class WhichCoord(Enum):
+    """which global coordinate system to use"""
+    HPS = "hps"
+    SVT = "svt"
+    LOCAL = "local"
+
+
 @app.command()
 def diff(
     input_file: List[Path],
-    local: bool = typer.Option(False, help="Comparing alignment parameters and not global positions/orientations"),
     out: Path = typer.Option("diff.pdf", help="output file name to print image to"),
-    which: str = typer.Option("hps", help="Which global coordinate system to use ('hps' or 'svt')")
+    which: WhichCoord = typer.Option(WhichCoord.HPS.value, help="Which coordinate system to use")
 ):
     """Plot difference between detectors and a reference detector.
 
@@ -21,7 +29,7 @@ def diff(
     rename files to helpful legend names if you wish.
     """
 
-    if local:
+    if which == WhichCoord.LOCAL:
         from ._load import _local as loader
         from ._table_fig import _local as plotter
         index = 'parameter'
@@ -30,35 +38,34 @@ def diff(
         from ._load import _global as loader
         from ._table_fig import _global as plotter
         index = 'sensor'
-        plot_kw = dict(which = which)
+        plot_kw = dict(which=which.value)
 
     data = [
         (inf.stem, loader(inf).set_index([index]))
         for inf in input_file
     ]
-    
+
     ref_name, ref_table = data[0]
-    
+
     # subtract away the first detector provided
     data = [
         (name, (df-ref_table).reset_index())
         for name, df in data[1:]
     ]
 
-
     plotter(
         data,
         out,
-        title = f'Difference Relative to {ref_name}',
+        title=f'Difference Relative to {ref_name}',
         **plot_kw
     )
+
 
 @app.command()
 def abs(
     input_file: List[Path],
-    local: bool = typer.Option(False, help="Comparing alignment parameters and not global positions/orientations"),
     out: Path = typer.Option("abs.pdf", help="output file name to print image to"),
-    which: str = typer.Option("hps", help="Which global coordinate system to use ('hps' or 'svt')")
+    which: WhichCoord = typer.Option(WhichCoord.HPS.value, help="Which coordinate system to use")
 ):
     """Plot the absolute position, overlaying all provided detectors
 
@@ -66,25 +73,25 @@ def abs(
     rename files to helpful legend names if you wish.
     """
 
-    if local:
+    if which == WhichCoord.LOCAL:
         from ._load import _local as loader
         from ._table_fig import _local as plotter
         plot_kw = dict(
-            title = 'Constant Values'
+            title='Constant Values'
         )
     else:
         from ._load import _global as loader
         from ._table_fig import _global as plotter
         plot_kw = dict(
-            which = which, 
-            title = 'Absolute Position and Orientation'
+            which=which.value,
+            title='Absolute Position and Orientation'
         )
 
     data = [
         (inf.stem, loader(inf))
         for inf in input_file
     ]
-    
+
     plotter(
         data,
         out,

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -1,0 +1,111 @@
+"""plot detector dumps to compare sensor positions and orientations"""
+
+from typing import List
+from pathlib import Path
+
+import typer
+
+from ._cli import app
+from . import _load
+
+def _table_fig(data_items, title, output_file, which='hps'):
+    """construct a table of figures using matplotlib subplots"""
+
+    import matplotlib.pyplot as plt
+    fig, axes = plt.subplots(
+        nrows = 3,
+        ncols = 2,
+        sharex = 'col'
+    )
+    fig.set_size_inches(17,8)
+
+    for i_c, c in enumerate(['x','y','z']):
+        for i_tr, tr in enumerate([which,'theta']):
+            # go through coordinates down columns and
+            # and position/rotation across rows
+            ax = axes[i_c][i_tr]
+            for name, data in data_items:
+                ax.scatter(
+                    data.sensor,
+                    data[f'{tr}{c}']*1000,
+                    label = name if i_c==0 and i_tr == 0 else '_no_legend'
+                )
+            if i_tr == 0:
+                ax.set_ylabel(f'{c.upper()} [$\mu$m]')
+            else:
+                ax.set_ylabel(f'$\\theta_{c}$ [mrad]')
+            ax.axhline(0.0, color='gray')
+            ax.grid(axis='x')
+            if c == 'x':
+                if i_tr == 0:
+                    if tr == 'hps':
+                        ax.set_title('HPS Global Position')
+                    else:
+                        ax.set_title('SVT Global Position')
+                else:
+                    ax.set_title('Euler Angle\n$\\theta_x = atan(v_z, w_z)$, $\\theta_y = -asin(u_z)$, $\\theta_z = atan(u_y, u_x)$')
+            if c == 'z':
+                ax.set_xticks(
+                    ax.get_xticks(),
+                    ax.get_xticklabels(),
+                    rotation=90
+                )
+    fig.legend(
+        title = title,
+        loc = 'lower center',
+        bbox_to_anchor = (0.5, 0.9)
+    )
+    fig.savefig(output_file, bbox_inches='tight')
+    plt.close()
+
+@app.command()
+def diff(
+    input_file: List[Path],
+    local: bool = typer.Option(False, help="Comparing alignment parameters and not global positions/orientations"),
+    out: Path = typer.Option("diff.pdf", help="output file name to print image to"),
+    which: str = typer.Option("hps", help="Which global coordinate system to use ('hps' or 'svt')")
+):
+    if local:
+        raise ValueError('local plot not implemented yet')
+
+    data = [
+        (inf.stem, _load.glbl(inf).set_index(["sensor"]))
+        for inf in input_file
+    ]
+
+    ref_name, ref_table = data[0]
+
+    # subtract away the first detector provided
+    data = [
+        (name, (df-ref_table).reset_index())
+        for name, df in data[1:]
+    ]
+
+    _table_fig(
+        data,
+        f"Different Relative to {ref_name}",
+        out,
+        which=which
+    )
+
+@app.command()
+def abs(
+    input_file: List[Path],
+    local: bool = typer.Option(False, help="Comparing alignment parameters and not global positions/orientations"),
+    out: Path = typer.Option("abs.pdf", help="output file name to print image to"),
+    which: str = typer.Option("hps", help="Which global coordinate system to use ('hps' or 'svt')")
+):
+    if local:
+        raise ValueError('local plot not implemented yet')
+
+    data = [
+        (inf.stem, _load.glbl(inf))
+        for inf in input_file
+    ]
+
+    _table_fig(
+        data,
+        "Absolute Position and Orientation",
+        out,
+        which=which
+    )

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -118,14 +118,14 @@ def plot(
         ref_table['lay'] = 0
         # subtract away the first detector provided
         data = [
-            (name, (df-ref_table).reset_index().sort_values('sortval').dropna(subset = ['ux']).reset_index(drop=True))
+            (name, (df-ref_table).reset_index().sort_values('sortval').dropna(subset=['ux']).reset_index(drop=True))
             for name, df in data[1:]
         ]
         # remove layers not in both years if comparing both detector versions
         if any(years) and not all(years) and years[0]:
-            data = [ (name, df[df.lay > 2.5]) for name, df in data ]
+            data = [(name, df[df.lay > 2.5]) for name, df in data]
         if any(years) and not all(years) and not years[0]:
-            data = [ (name, df[df.lay > 1.5]) for name, df in data ]
+            data = [(name, df[df.lay > 1.5]) for name, df in data]
         # change plot title
         plot_kw['title'] = f'Difference Relative to {ref_name}'
 

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -49,7 +49,7 @@ def plot(
     input_file: List[Path],
     out: Path = typer.Option(None, help="output file name to print image to, default is <plot>.pdf"),
     coord: Coord = typer.Option(Coord.GLOBAL.value, help="which coordinate system to use"),
-    angle: Angle = typer.Option(Angle.axis.value, help='which angle definition to use in global coordinates'),
+    angle: Angle = typer.Option(Angle.expected_axis.value, help='which angle definition to use in global coordinates'),
     pos: Position = typer.Option(Position.HPS.value, help='which position definition to use in global coordinates'),
     plot: Plot = typer.Option(Plot.ABS.value, help='What type of plot to make')
 ):

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -6,91 +6,82 @@ from enum import Enum
 
 import typer
 
-from ._cli import app
+from .._cli import app
 
 
 class WhichCoord(Enum):
-    """which global coordinate system to use"""
+    """which coordinate system to use"""
     HPS = "hps"
+    """coordinates relative to entire HPS detector"""
     SVT = "svt"
+    """coordinates relative to SVT frame"""
     LOCAL = "local"
+    """coordinates relative to each sensor individually i.e. the alignment constants themselves"""
+
+
+class WhichPlot(Enum):
+    """which type of comparison plot to use"""
+    ABS = "abs"
+    """plot all values in absolute terms"""
+    DIFF = "diff"
+    """subtract all values by the reference values"""
 
 
 @app.command()
-def diff(
+def plot(
     input_file: List[Path],
-    out: Path = typer.Option("diff.pdf", help="output file name to print image to"),
-    which: WhichCoord = typer.Option(WhichCoord.HPS.value, help="Which coordinate system to use")
+    out: Path = typer.Option(None, help="output file name to print image to, default is <plot>.pdf"),
+    which: WhichCoord = typer.Option(WhichCoord.HPS.value, help="Which coordinate system to use"),
+    plot: WhichPlot = typer.Option(WhichPlot.ABS.value, help='What type of plot to make')
 ):
-    """Plot difference between detectors and a reference detector.
+    """Plot detector coordinate and orientation data
 
-    The reference detector is the first detector provided in the input list.
+    If the 'diff' <plot> is chosen, then all values are subtracted by their
+    reference values which are defined by the first detector provided in the
+    input list.
+
     All detectors are named after the name of the file. Use soft links to
     rename files to helpful legend names if you wish.
     """
+
+    if out is None:
+        out = plot.value + '.pdf'
 
     if which == WhichCoord.LOCAL:
         from ._load import _local as loader
         from ._table_fig import _local as plotter
         index = 'parameter'
         plot_kw = dict()
+        if plot == WhichPlot.ABS:
+            plot_kw['title'] = 'Constant Values'
     else:
         from ._load import _global as loader
         from ._table_fig import _global as plotter
         index = 'sensor'
         plot_kw = dict(which=which.value)
-
-    data = [
-        (inf.stem, loader(inf).set_index([index]))
-        for inf in input_file
-    ]
-
-    ref_name, ref_table = data[0]
-
-    # subtract away the first detector provided
-    data = [
-        (name, (df-ref_table).reset_index())
-        for name, df in data[1:]
-    ]
-
-    plotter(
-        data,
-        out,
-        title=f'Difference Relative to {ref_name}',
-        **plot_kw
-    )
-
-
-@app.command()
-def abs(
-    input_file: List[Path],
-    out: Path = typer.Option("abs.pdf", help="output file name to print image to"),
-    which: WhichCoord = typer.Option(WhichCoord.HPS.value, help="Which coordinate system to use")
-):
-    """Plot the absolute position, overlaying all provided detectors
-
-    All detectors are named after the name of the provided file. Use soft links `ln -s` to
-    rename files to helpful legend names if you wish.
-    """
-
-    if which == WhichCoord.LOCAL:
-        from ._load import _local as loader
-        from ._table_fig import _local as plotter
-        plot_kw = dict(
-            title='Constant Values'
-        )
-    else:
-        from ._load import _global as loader
-        from ._table_fig import _global as plotter
-        plot_kw = dict(
-            which=which.value,
-            title='Absolute Position and Orientation'
-        )
+        if plot == WhichPlot.ABS:
+            plot_kw['title'] = 'Absolute Position and Orientation'
 
     data = [
         (inf.stem, loader(inf))
         for inf in input_file
     ]
+
+    if plot == WhichPlot.DIFF:
+        if len(data) < 2:
+            raise ValueError('Must provide 2 or more detectors to make a diff plot!')
+        # set the index so subtraction lines up along ID
+        for _name, df in data:
+            df.set_index([index], inplace=True)
+        # get reference detector
+        ref_name, ref_table = data[0]
+        # subtract away the first detector provided
+        data = [
+            (name, (df-ref_table).reset_index())
+            for name, df in data[1:]
+        ]
+        # change plot title
+        plot_kw['title'] = f'Difference Relative to {ref_name}'
 
     plotter(
         data,

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -6,57 +6,6 @@ from pathlib import Path
 import typer
 
 from ._cli import app
-from . import _load
-
-def _table_fig(data_items, title, output_file, which='hps'):
-    """construct a table of figures using matplotlib subplots"""
-
-    import matplotlib.pyplot as plt
-    fig, axes = plt.subplots(
-        nrows = 3,
-        ncols = 2,
-        sharex = 'col'
-    )
-    fig.set_size_inches(17,8)
-
-    for i_c, c in enumerate(['x','y','z']):
-        for i_tr, tr in enumerate([which,'theta']):
-            # go through coordinates down columns and
-            # and position/rotation across rows
-            ax = axes[i_c][i_tr]
-            for name, data in data_items:
-                ax.scatter(
-                    data.sensor,
-                    data[f'{tr}{c}']*1000,
-                    label = name if i_c==0 and i_tr == 0 else '_no_legend'
-                )
-            if i_tr == 0:
-                ax.set_ylabel(f'{c.upper()} [$\mu$m]')
-            else:
-                ax.set_ylabel(f'$\\theta_{c}$ [mrad]')
-            ax.axhline(0.0, color='gray')
-            ax.grid(axis='x')
-            if c == 'x':
-                if i_tr == 0:
-                    if tr == 'hps':
-                        ax.set_title('HPS Global Position')
-                    else:
-                        ax.set_title('SVT Global Position')
-                else:
-                    ax.set_title('Euler Angle\n$\\theta_x = atan(v_z, w_z)$, $\\theta_y = -asin(u_z)$, $\\theta_z = atan(u_y, u_x)$')
-            if c == 'z':
-                ax.set_xticks(
-                    ax.get_xticks(),
-                    ax.get_xticklabels(),
-                    rotation=90
-                )
-    fig.legend(
-        title = title,
-        loc = 'lower center',
-        bbox_to_anchor = (0.5, 0.9)
-    )
-    fig.savefig(output_file, bbox_inches='tight')
-    plt.close()
 
 @app.command()
 def diff(
@@ -73,26 +22,35 @@ def diff(
     """
 
     if local:
-        raise ValueError('local plotting not implemented yet')
+        from ._load import _local as loader
+        from ._table_fig import _local as plotter
+        index = 'parameter'
+        plot_kw = dict()
+    else:
+        from ._load import _global as loader
+        from ._table_fig import _global as plotter
+        index = 'sensor'
+        plot_kw = dict(which = which)
 
     data = [
-        (inf.stem, _load.glbl(inf).set_index(["sensor"]))
+        (inf.stem, loader(inf).set_index([index]))
         for inf in input_file
     ]
-
+    
     ref_name, ref_table = data[0]
-
+    
     # subtract away the first detector provided
     data = [
         (name, (df-ref_table).reset_index())
         for name, df in data[1:]
     ]
 
-    _table_fig(
+
+    plotter(
         data,
-        f"Different Relative to {ref_name}",
         out,
-        which=which
+        title = f'Difference Relative to {ref_name}',
+        **plot_kw
     )
 
 @app.command()
@@ -109,16 +67,26 @@ def abs(
     """
 
     if local:
-        raise ValueError('local plotting not implemented yet')
+        from ._load import _local as loader
+        from ._table_fig import _local as plotter
+        plot_kw = dict(
+            title = 'Constant Values'
+        )
+    else:
+        from ._load import _global as loader
+        from ._table_fig import _global as plotter
+        plot_kw = dict(
+            which = which, 
+            title = 'Absolute Position and Orientation'
+        )
 
     data = [
-        (inf.stem, _load.glbl(inf))
+        (inf.stem, loader(inf))
         for inf in input_file
     ]
-
-    _table_fig(
+    
+    plotter(
         data,
-        "Absolute Position and Orientation",
         out,
-        which=which
+        **plot_kw
     )

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -64,7 +64,10 @@ def plot(
     """
 
     if out is None:
-        out = plot.value + '.pdf'
+        default_name = plot.value
+        if len(input_file) == 1:
+            default_name = input_file[0].stem
+        out = str(default_name) + '.pdf'
 
     if coord == Coord.LOCAL:
         from ._load import _local as loader

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -118,14 +118,14 @@ def plot(
             (
                 name,
                 # I group the sensors by their sensor name with '_axial' and '_stereo' removed,
-                # this pairs up all sensors into modules which I can then 'sum()' over the different
-                # coordinates in the set and '/2' to get the average
+                # this pairs up all sensors into modules which I can then 'mean()' over the different
+                # coordinates to get the average
                 # Then I resort by sortval for nicer-looking plots after 'reset_index()' so that the
                 # 'sensor' column name is available again - it is now the module name (i.e. same as
                 # before but with '_axial' and '_stereo' removed
                 (df.set_index('sensor').groupby(
                     lambda s: s.replace('_axial', '').replace('_stereo', '')
-                ).sum()/2).reset_index().sort_values(
+                ).mean()).reset_index().sort_values(
                     'sortval'
                 )
             ) for name, df in data

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -116,7 +116,7 @@ def plot(
             raise Exception('Merging modules together for raw alignment constants is not implemented.')
         data = [
             (
-                name, 
+                name,
                 # I group the sensors by their sensor name with '_axial' and '_stereo' removed,
                 # this pairs up all sensors into modules which I can then 'sum()' over the different
                 # coordinates in the set and '/2' to get the average
@@ -124,7 +124,7 @@ def plot(
                 # 'sensor' column name is available again - it is now the module name (i.e. same as
                 # before but with '_axial' and '_stereo' removed
                 (df.set_index('sensor').groupby(
-                    lambda s: s.replace('_axial','').replace('_stereo','')
+                    lambda s: s.replace('_axial', '').replace('_stereo', '')
                 ).sum()/2).reset_index().sort_values(
                     'sortval'
                 )

--- a/src/hps_align/detdump/plot/__init__.py
+++ b/src/hps_align/detdump/plot/__init__.py
@@ -95,6 +95,7 @@ def plot(
         )
         if plot == Plot.ABS:
             plot_kw['title'] = 'Absolute Position and Orientation'
+            plot_kw['ref_line'] = None
 
     data = [
         (inf.stem, loader(inf, **load_kw))

--- a/src/hps_align/detdump/plot/_angles.py
+++ b/src/hps_align/detdump/plot/_angles.py
@@ -197,10 +197,8 @@ def expected_axis(df: pd.DataFrame):
         dataframe with u, v, w coordinate vectors
     """
 
-    is2016 = not any(df.sensor.str.contains('L7'))
-
     vx_neg_sl = (
-        ((df.lay < 3) & (df.sensor.str.contains('stereo'))) |
+        ((df.lay < 2.5) & (df.sensor.str.contains('stereo'))) |
         (df.sensor.str.contains('slot'))
     )
     uy_neg_sl = (
@@ -216,6 +214,24 @@ def expected_axis(df: pd.DataFrame):
         df.sensor.str.contains('t_axial')
         | df.sensor.str.contains('b_stereo')
     )
+
+    # check for 2016
+    if not any(df.sensor.str.contains('L7')):
+        # change slices for 2016
+        #   Front only has three layers now
+        #   All three front layers behave together
+        #   (i.e. no L12/L34 separate like there is above
+        vx_neg_sl = (
+            (df.sensor.str.contains('slot'))
+        )
+        uy_neg_sl = (
+            ((df.lay < 3.5) & (df.sensor.str.contains('t_stereo')))
+            | ((df.lay < 3.5) & (df.sensor.str.contains('b_axial')))
+            | (df.sensor.str.contains('t_axial_slot'))
+            | (df.sensor.str.contains('t_stereo_hole'))
+            | (df.sensor.str.contains('b_axial_hole'))
+            | (df.sensor.str.contains('b_stereo_slot'))
+        )
 
     df['thetax'] = np.arccos((-1*vx_neg_sl+1*(~vx_neg_sl))*df.vx)
     df['thetay'] = np.arccos((-1*uy_neg_sl+1*(~uy_neg_sl))*df.uy)

--- a/src/hps_align/detdump/plot/_angles.py
+++ b/src/hps_align/detdump/plot/_angles.py
@@ -1,0 +1,93 @@
+"""module for calculating different angles from coordinate axes"""
+
+import functools
+
+import numpy as np
+import pandas as pd
+
+
+def angle_calculator(f):
+    """decorator for registering angle calculators"""
+    angle_calculator.__registry__[f.__name__] = f
+    # set default title
+    f.__title__ = f.__name__
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
+    return wrapper
+
+
+angle_calculator.__registry__ = dict()
+"""registry of angle calculators"""
+
+
+@angle_calculator
+def euler(df: pd.DataFrame):
+    r"""One definition of the Euler angles
+
+    This code is not currently being used by the global loader
+    but it is here for easy drop-in if users wish. Just change
+    which angle_calculator is used when the global loader
+    is being called.
+
+    .. math::
+
+        \theta_x = \arctan\left(\frac{v_z}{w_z}\right)
+
+    .. math::
+
+        \theta_y = -\arcsin(u_z)
+
+    .. math::
+
+        \theta_z = \arctan\left(\frac{u_y}{u_x}\right)
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        dataframe with u, v, w coordinate vectors
+
+    Returns
+    -------
+    Tuple[pd.Series]
+        the three-tuple of the three euler angles
+    """
+    df['thetax'] = np.arctan2(df.vz, df.wz)
+    df['thetay'] = -np.arcsin(df.uz)
+    df['thetaz'] = np.arctan2(df.uy, df.ux)
+
+
+euler.__title__ = r"""Euler Angles
+$\theta_x = atan(v_z/w_z)$ $\theta_y = -asin(u_z)$ $\theta_z = atan(u_y/u_x)$"""
+
+
+@angle_calculator
+def axis(df: pd.DataFrame):
+    r"""Calculate the angles relative to the known global axes
+    the local axes are close to.
+
+    .. math::
+
+        \theta_x = \arccos(v_x)
+
+    .. math::
+
+        \theta_y = \arccos(u_y)
+
+    .. math::
+
+        \theta_z = \arccos(w_z)
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        dataframe with u, v, w coordinate vectors
+    """
+    df['thetax'] = np.arccos(df.vx)
+    df['thetay'] = np.arccos(df.uy)
+    df['thetaz'] = np.arccos(df.wz)
+
+
+axis.__title__ = r"""Axis Angles
+$\theta_x = acos(v_x)$ $\theta_y = acos(u_y)$ $\theta_z = acos(w_z)$"""

--- a/src/hps_align/detdump/plot/_angles.py
+++ b/src/hps_align/detdump/plot/_angles.py
@@ -238,5 +238,5 @@ def expected_axis(df: pd.DataFrame):
     df['thetaz'] = np.arccos((-1*wz_neg_sl+1*(~wz_neg_sl))*df.wz)
 
 
-axis.__title__ = r"""Expected Axis Angles
+expected_axis.__title__ = r"""Expected Axis Angles
 $\theta_x = acos(\pm v_x)$ $\theta_y = acos(\pm u_y)$ $\theta_z = acos(\pm w_z)$"""

--- a/src/hps_align/detdump/plot/_angles.py
+++ b/src/hps_align/detdump/plot/_angles.py
@@ -1,7 +1,5 @@
 """module for calculating different angles from coordinate axes"""
 
-import functools
-
 import numpy as np
 import pandas as pd
 
@@ -11,11 +9,7 @@ def angle_calculator(f):
     angle_calculator.__registry__[f.__name__] = f
     # set default title
     f.__title__ = f.__name__
-
-    @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        return f(*args, **kwargs)
-    return wrapper
+    return f
 
 
 angle_calculator.__registry__ = dict()

--- a/src/hps_align/detdump/plot/_angles.py
+++ b/src/hps_align/detdump/plot/_angles.py
@@ -206,6 +206,7 @@ def expected_axis(df: pd.DataFrame):
     uy_neg_sl = (
         ((df.lay > 2.5) & (df.lay < 4.5) & (df.sensor.str.contains('t_stereo')))
         | ((df.lay < 4.5) & (df.sensor.str.contains('b_axial')))
+        | ((df.lay < 2.5) & (df.sensor.str.contains('b_stereo')))
         | (df.sensor.str.contains('t_axial_slot'))
         | (df.sensor.str.contains('t_stereo_hole'))
         | (df.sensor.str.contains('b_axial_hole'))

--- a/src/hps_align/detdump/plot/_cli.py
+++ b/src/hps_align/detdump/plot/_cli.py
@@ -1,0 +1,5 @@
+"""construct a sub-app for our typer app"""
+
+import typer
+
+app = typer.Typer()

--- a/src/hps_align/detdump/plot/_cli.py
+++ b/src/hps_align/detdump/plot/_cli.py
@@ -1,5 +1,0 @@
-"""construct a sub-app for our typer app"""
-
-import typer
-
-app = typer.Typer()

--- a/src/hps_align/detdump/plot/_load.py
+++ b/src/hps_align/detdump/plot/_load.py
@@ -34,8 +34,6 @@ def _global(f: Path, angle_calculator=axis):
     """
     df = pd.read_csv(f)
 
-    angle_calculator(df)
-
     df.drop(
         df[df.sensor.str.contains('ECalScoring')].index,
         inplace=True
@@ -49,6 +47,7 @@ def _global(f: Path, angle_calculator=axis):
     df['side'] = df.sensor.apply(lambda s: 1.0 if s[-1] == 't' else 0.0)
     df['sortval'] = 500.0*df.vol + 2.0*df.tilt + 1.0*df.side + 4.0*df.lay
     df = df.sort_values('sortval')
+    angle_calculator(df)
     return df
 
 

--- a/src/hps_align/detdump/plot/_load.py
+++ b/src/hps_align/detdump/plot/_load.py
@@ -60,9 +60,12 @@ def _global(f: Path):
     )
     #df.drop(columns = meas_cols, inplace=True)
 
-    df['thetax'] = np.arctan2(df.vz, df.wz)
-    df['thetay'] = -np.arcsin(df.uz)
-    df['thetaz'] = np.arctan2(df.uy, df.ux)
+    #df['thetax'] = np.arctan2(df.vz, df.wz)
+    #df['thetay'] = -np.arcsin(df.uz)
+    #df['thetaz'] = np.arctan2(df.uy, df.ux)
+    df['thetax'] = np.arccos(df.vx)
+    df['thetay'] = np.arccos(df.uy)
+    df['thetaz'] = np.arccos(df.wz)
 
     df.reset_index(names='sensor', inplace=True)
     df.drop(

--- a/src/hps_align/detdump/plot/_load.py
+++ b/src/hps_align/detdump/plot/_load.py
@@ -38,7 +38,7 @@ def _read_multitype(f: Path):
         return NotImplemented
 
 
-def glbl(f: Path):
+def _global(f: Path):
     r"""transform input global detdump into in-memory data table
 
     We calculate the Euler angles here which are just one definition.
@@ -75,7 +75,7 @@ def glbl(f: Path):
     return df
 
 
-def lcl(f: Path):
+def _local(f: Path):
     """Load the alignment constants from the input path
 
     Also convert a alignment constant ID number into its t_r and u_v_w
@@ -86,5 +86,6 @@ def lcl(f: Path):
     df['value'] = df.value.apply(pd.eval)
     df['t_r'] = (df.parameter % 10000) // 1000
     df['u_v_w'] = (df.parameter % 1000) // 100
+    df['individual'] = (df.parameter % 100 < 23) & (df.parameter % 100 > 0)
     df.sort_values('parameter', inplace=True)
     return df

--- a/src/hps_align/detdump/plot/_load.py
+++ b/src/hps_align/detdump/plot/_load.py
@@ -59,7 +59,7 @@ def _global(f: Path):
     df['lay'] = df.sensor.apply(lambda s: int(s[1]))
     df['vol'] = df.sensor.apply(lambda s: 1.0 if s[2] == 'b' else 0.0)
     df['tilt'] = df.sensor.apply(lambda s: 1.0 if (s[2] == 'b' and s[4] == 'a') or (s[2] == 't' and s[4] == 's') else 0.0)
-    df['side'] = df.sensor.apply(lambda s: 1.0 if int(s[1]) > 4 and s[-1] == 't' else 0.0)
+    df['side'] = df.sensor.apply(lambda s: 1.0 if s[-1] == 't' else 0.0)
     df['sortval'] = 500.0*df.vol + 2.0*df.tilt + 1.0*df.side + 4.0*df.lay
     df = df.sort_values('sortval')
     return df

--- a/src/hps_align/detdump/plot/_load.py
+++ b/src/hps_align/detdump/plot/_load.py
@@ -42,9 +42,6 @@ def _global(f: Path):
     """
     df = pd.read_csv(f)
 
-    #df['thetax'] = np.arctan2(df.vz, df.wz)
-    #df['thetay'] = -np.arcsin(df.uz)
-    #df['thetaz'] = np.arctan2(df.uy, df.ux)
     df['thetax'] = np.arccos(df.vx)
     df['thetay'] = np.arccos(df.uy)
     df['thetaz'] = np.arccos(df.wz)

--- a/src/hps_align/detdump/plot/_load.py
+++ b/src/hps_align/detdump/plot/_load.py
@@ -5,66 +5,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-
-def euler(df: pd.DataFrame):
-    r"""One definition of the Euler angles
-
-    This code is not currently being used by the global loader
-    but it is here for easy drop-in if users wish. Just change
-    which angle_calculator is used when the global loader
-    is being called.
-
-    .. math::
-
-        \theta_x = \arctan\left(\frac{v_z}{w_z}\right)
-
-    .. math::
-
-        \theta_y = -\arcsin(u_z)
-
-    .. math::
-
-        \theta_z = \arctan\left(\frac{u_y}{u_x}\right)
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        dataframe with u, v, w coordinate vectors
-
-    Returns
-    -------
-    Tuple[pd.Series]
-        the three-tuple of the three euler angles
-    """
-    df['thetax'] = np.arctan2(df.vz, df.wz),
-    df['thetay'] = -np.arcsin(df.uz),
-    df['thetaz'] = np.arctan2(df.uy, df.ux)
-
-
-def axis(df: pd.DataFrame):
-    r"""Calculate the angles relative to the known global axes
-    the local axes are close to.
-
-    .. math::
-
-        \theta_x = \arccos(v_x)
-
-    .. math::
-
-        \theta_y = \arccos(u_y)
-
-    .. math::
-
-        \theta_z = \arccos(w_z)
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        dataframe with u, v, w coordinate vectors
-    """
-    df['thetax'] = np.arccos(df.vx)
-    df['thetay'] = np.arccos(df.uy)
-    df['thetaz'] = np.arccos(df.wz)
+from ._angles import axis
 
 
 def _global(f: Path, angle_calculator=axis):

--- a/src/hps_align/detdump/plot/_load.py
+++ b/src/hps_align/detdump/plot/_load.py
@@ -58,7 +58,7 @@ def _global(f: Path):
         columns = lambda colname : colname[:3]+colname[-1] if 'position' in colname and colname != 'position' else colname,
         inplace=True
     )
-    df.drop(columns = meas_cols, inplace=True)
+    #df.drop(columns = meas_cols, inplace=True)
 
     df['thetax'] = np.arctan2(df.vz, df.wz)
     df['thetay'] = -np.arcsin(df.uz)
@@ -72,6 +72,12 @@ def _global(f: Path):
 
     # shorten sensor name
     df['sensor'] = df.sensor.apply(lambda s: s.replace('module0_','').replace('_sensor0','').replace('halfmodule_','').replace('module_',''))
+    df['lay'] = df.sensor.apply(lambda s: int(s[1]))
+    df['vol'] = df.sensor.apply(lambda s: 1.0 if s[2] == 'b' else 0.0)
+    df['tilt'] = df.sensor.apply(lambda s: 1.0 if (s[2] == 'b' and s[4] == 'a') or (s[2] == 't' and s[4] == 's') else 0.0)
+    df['side'] = df.sensor.apply(lambda s: 1.0 if int(s[1]) > 4 and s[-1] == 't' else 0.0)
+    df['sortval'] = 500.0*df.vol + 2.0*df.tilt + 1.0*df.side + 4.0*df.lay
+    df = df.sort_values('sortval')
     return df
 
 

--- a/src/hps_align/detdump/plot/_load.py
+++ b/src/hps_align/detdump/plot/_load.py
@@ -52,6 +52,69 @@ def _global(f: Path, angle_calculator=axis):
     return df
 
 
+def _global_is2016(df: pd.DataFrame):
+    """check if the input dataframe holdinging geometry information is from 2016 or not
+
+    This check is currently only valid for global coordinates.
+
+    For global coordinates, the distinguishing factor between 2016 and post-upgrade
+    years is the presence of a 7th layer.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        dataframe of sensor coordinates and positions
+
+
+    Returns
+    -------
+    bool:
+        True if dataframe represents a 2016 detector
+    """
+
+    return not any(df.sensor.str.contains('L7'))
+
+
+_global_remap2016 = {
+    'L1t_axial': 'L2t_axial',
+    'L1t_stereo': 'L2t_stereo',
+    'L2t_axial': 'L3t_axial',
+    'L2t_stereo': 'L3t_stereo',
+    'L3t_axial': 'L4t_axial',
+    'L3t_stereo': 'L4t_stereo',
+    'L4t_axial_hole': 'L5t_axial_hole',
+    'L4t_stereo_hole': 'L5t_stereo_hole',
+    'L4t_axial_slot': 'L5t_axial_slot',
+    'L4t_stereo_slot': 'L5t_stereo_slot',
+    'L5t_axial_hole': 'L6t_axial_hole',
+    'L5t_stereo_hole': 'L6t_stereo_hole',
+    'L5t_axial_slot': 'L6t_axial_slot',
+    'L5t_stereo_slot': 'L6t_stereo_slot',
+    'L6t_axial_hole': 'L7t_axial_hole',
+    'L6t_stereo_hole': 'L7t_stereo_hole',
+    'L6t_axial_slot': 'L7t_axial_slot',
+    'L6t_stereo_slot': 'L7t_stereo_slot',
+    'L1b_axial': 'L2b_axial',
+    'L1b_stereo': 'L2b_stereo',
+    'L2b_axial': 'L3b_axial',
+    'L2b_stereo': 'L3b_stereo',
+    'L3b_axial': 'L4b_axial',
+    'L3b_stereo': 'L4b_stereo',
+    'L4b_axial_hole': 'L5b_axial_hole',
+    'L4b_stereo_hole': 'L5b_stereo_hole',
+    'L4b_axial_slot': 'L5b_axial_slot',
+    'L4b_stereo_slot': 'L5b_stereo_slot',
+    'L5b_axial_hole': 'L6b_axial_hole',
+    'L5b_stereo_hole': 'L6b_stereo_hole',
+    'L5b_axial_slot': 'L6b_axial_slot',
+    'L5b_stereo_slot': 'L6b_stereo_slot',
+    'L6b_axial_hole': 'L7b_axial_hole',
+    'L6b_stereo_hole': 'L7b_stereo_hole',
+    'L6b_axial_slot': 'L7b_axial_slot',
+    'L6b_stereo_slot': 'L7b_stereo_slot',
+}
+
+
 def _local(f: Path):
     """Load the alignment constants from the input path
 
@@ -86,3 +149,14 @@ def _local(f: Path):
     df['individual'] = (df.parameter % 100 < 23) & (df.parameter % 100 > 0)
     df.sort_values('parameter', inplace=True)
     return df
+
+
+def _local_is2016(df: pd.DataFrame):
+    """determine if a local-coordinate dataframe is 2016
+
+    not implemented
+    """
+    return False
+
+
+_local_remap2016 = dict()

--- a/src/hps_align/detdump/plot/_load.py
+++ b/src/hps_align/detdump/plot/_load.py
@@ -1,0 +1,90 @@
+"""load detector parameters dumped to a file"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from .._write import OutputType
+
+def _read_multitype(f: Path):
+    """Load the input file from any of the supported detdump output types
+
+    Parameters
+    ----------
+    f : str | Path
+      file path to file with detector dump
+
+    Returns
+    -------
+    pd.DataFrame
+        dataframe loaded from that file
+    """
+
+    if not isinstance(f, Path):
+        f = Path(f)
+
+    if not f.is_file():
+        raise ValueError(f'File {f} does not exist.')
+
+    if not OutputType.valid(f):
+        raise ValueError(f'File {f} does not have a supported extension.')
+
+    if f.suffix == '.csv':
+        return pd.read_csv(f)
+    elif f.suffix == '.json':
+        return pd.read_json(f).transpose()
+    else:
+        return NotImplemented
+
+
+def glbl(f: Path):
+    r"""transform input global detdump into in-memory data table
+
+    We calculate the Euler angles here which are just one definition.
+
+    .. math::
+
+        \tan\theta_x = \frac{v_z}{w_z}
+        \sin\theta_y = -u_z
+        \tan\theta_z = \frac{u_y}{u_x}
+
+    """
+    df = _read_multitype(f)
+    meas_cols = ['hps_position','svt_position','u','v','w']
+    for meas in meas_cols:
+        df[[f'{meas}x',f'{meas}y',f'{meas}z']] = df[meas].tolist()
+    df.rename(
+        columns = lambda colname : colname[:3]+colname[-1] if 'position' in colname and colname != 'position' else colname,
+        inplace=True
+    )
+    df.drop(columns = meas_cols, inplace=True)
+
+    df['thetax'] = np.arctan2(df.vz, df.wz)
+    df['thetay'] = -np.arcsin(df.uz)
+    df['thetaz'] = np.arctan2(df.uy, df.ux)
+
+    df.reset_index(names='sensor', inplace=True)
+    df.drop(
+        df[df.sensor.str.contains('ECalScoring')].index,
+        inplace=True
+    )
+
+    # shorten sensor name
+    df['sensor'] = df.sensor.apply(lambda s: s.replace('module0_','').replace('_sensor0','').replace('halfmodule_','').replace('module_',''))
+    return df
+
+
+def lcl(f: Path):
+    """Load the alignment constants from the input path
+
+    Also convert a alignment constant ID number into its t_r and u_v_w
+    for later plot categorization.
+    """
+
+    df = _read_multitype(f)
+    df['value'] = df.value.apply(pd.eval)
+    df['t_r'] = (df.parameter % 10000) // 1000
+    df['u_v_w'] = (df.parameter % 1000) // 100
+    df.sort_values('parameter', inplace=True)
+    return df

--- a/src/hps_align/detdump/plot/_table_fig.py
+++ b/src/hps_align/detdump/plot/_table_fig.py
@@ -98,7 +98,8 @@ def _global(data_items, output_file, title = None, which='hps', **kwargs):
                     else:
                         ax.set_title('SVT Global Position')
                 else:
-                    ax.set_title('Euler Angle\n$\\theta_x = atan(v_z, w_z)$, $\\theta_y = -asin(u_z)$, $\\theta_z = atan(u_y, u_x)$')
+                    ax.set_title('Axis Angles\n$\\theta_x = acos(v_x)$, $\\theta_y = acos(u_y)$, $\\theta_z = acos(w_z)$')
+                    #ax.set_title('Euler Angle\n$\\theta_x = atan(v_z, w_z)$, $\\theta_y = -asin(u_z)$, $\\theta_z = atan(u_y, u_x)$')
             if c == 'z':
                 ax.set_xticks(
                     ax.get_xticks(),

--- a/src/hps_align/detdump/plot/_table_fig.py
+++ b/src/hps_align/detdump/plot/_table_fig.py
@@ -4,7 +4,19 @@
 def _local(data_items, output_file, title=None, **kwargs):
     """the local coordinate system is plotted in a 2x4 grid where
     the top row is translations, the bottom row is rotations, and
-    the last entry in the bottom row is for structure constants"""
+    the last entry in the bottom row is for structure constants
+
+    Parameters
+    ----------
+    data_items: List[Tuple[str,pd.DataFrame]]
+        items of data with corresponding names to plot
+    output_file: str | pathlib.Path
+        output file to write resulting figure to
+    title: str, optional
+        title to add onto legend. Default is None.
+    **kwargs: dict, optional
+        the rest of the keyword arguments are absorbed but then ignored
+    """
 
     import matplotlib.pyplot as plt
     fig, axes = plt.subplots(
@@ -65,7 +77,21 @@ def _local(data_items, output_file, title=None, **kwargs):
 def _global(data_items, output_file, title=None, which='hps', **kwargs):
     """the global coordinate system is plottined in a 3x2 grid
     where the first column is position and the second column is
-    euler angles. The rows go through x, y, z."""
+    euler angles. The rows go through x, y, z.
+
+    Parameters
+    ----------
+    data_items: List[Tuple[str,pd.DataFrame]]
+        items of data with corresponding names to plot
+    output_file: str | pathlib.Path
+        output file to write resulting figure to
+    title: str, optional
+        title to add onto legend. Default is None.
+    which: str, optional
+        which positional coordinates to use. Default is 'hps'.
+    **kwargs: dict, optional
+        the rest of the keyword arguments are absorbed but then ignored
+    """
 
     import matplotlib.pyplot as plt
     fig, axes = plt.subplots(

--- a/src/hps_align/detdump/plot/_table_fig.py
+++ b/src/hps_align/detdump/plot/_table_fig.py
@@ -74,7 +74,7 @@ def _local(data_items, output_file, title=None, **kwargs):
     plt.clear()
 
 
-def _global(data_items, output_file, title=None, which='hps', **kwargs):
+def _global(data_items, output_file, title=None, position='hps', angle_title='Angles', **kwargs):
     """the global coordinate system is plottined in a 3x2 grid
     where the first column is position and the second column is
     euler angles. The rows go through x, y, z.
@@ -87,8 +87,10 @@ def _global(data_items, output_file, title=None, which='hps', **kwargs):
         output file to write resulting figure to
     title: str, optional
         title to add onto legend. Default is None.
-    which: str, optional
+    position: str, optional
         which positional coordinates to use. Default is 'hps'.
+    angle_title: str, optional
+        title to have above the angle columns, useful for defining what angles are being plotted
     **kwargs: dict, optional
         the rest of the keyword arguments are absorbed but then ignored
     """
@@ -102,7 +104,7 @@ def _global(data_items, output_file, title=None, which='hps', **kwargs):
     fig.set_size_inches(17, 8)
 
     for i_c, c in enumerate(['x', 'y', 'z']):
-        for i_tr, tr in enumerate([which, 'theta']):
+        for i_tr, tr in enumerate([position, 'theta']):
             # go through coordinates down columns and
             # and position/rotation across rows
             ax = axes[i_c][i_tr]
@@ -125,7 +127,7 @@ def _global(data_items, output_file, title=None, which='hps', **kwargs):
                     else:
                         ax.set_title('SVT Global Position')
                 else:
-                    ax.set_title('Axis Angles\n$\\theta_x = acos(v_x)$, $\\theta_y = acos(u_y)$, $\\theta_z = acos(w_z)$')
+                    ax.set_title(angle_title)
             if c == 'z':
                 ax.set_xticks(
                     ax.get_xticks(),

--- a/src/hps_align/detdump/plot/_table_fig.py
+++ b/src/hps_align/detdump/plot/_table_fig.py
@@ -1,30 +1,31 @@
 """construct different kinds of figures with tables of subplots"""
 
-def _local(data_items, output_file, title = None, **kwargs):
+
+def _local(data_items, output_file, title=None, **kwargs):
     """the local coordinate system is plotted in a 2x4 grid where
     the top row is translations, the bottom row is rotations, and
     the last entry in the bottom row is for structure constants"""
 
     import matplotlib.pyplot as plt
     fig, axes = plt.subplots(
-        nrows = 2,
-        ncols = 4,
-        gridspec_kw = dict(
-            wspace = 0.2,
-            hspace = 0.3,
+        nrows=2,
+        ncols=4,
+        gridspec_kw=dict(
+            wspace=0.2,
+            hspace=0.3,
         )
     )
-    fig.set_size_inches(17,8)
+    fig.set_size_inches(17, 8)
 
-    for tr, i_tr in [('t',1),('r',2)]:
-        for uvw, i_uvw in [('u',1),('v',2),('w',3)]:
+    for tr, i_tr in [('t', 1), ('r', 2)]:
+        for uvw, i_uvw in [('u', 1), ('v', 2), ('w', 3)]:
             ax = axes[i_tr-1][i_uvw-1]
             for name, df in data_items:
-                sl = (df.t_r == i_tr)&(df.u_v_w == i_uvw)
+                sl = (df.t_r == i_tr) & (df.u_v_w == i_uvw)
                 ax.scatter(
                     df[sl].parameter.apply(str),
                     df[sl].value*1000,
-                    label = name if (i_tr == 1 and i_uvw == 1) else '_no_legend'
+                    label=name if (i_tr == 1 and i_uvw == 1) else '_no_legend'
                 )
             ax.set_xticks(
                 ax.get_xticks(),
@@ -37,7 +38,7 @@ def _local(data_items, output_file, title = None, **kwargs):
             ax.set_title(f'{tr}{uvw}')
             if i_uvw == 1:
                 if i_tr == 1:
-                    ax.set_ylabel('$\mu m$')
+                    ax.set_ylabel('$\\mu m$')
                 else:
                     ax.set_ylabel('mrad')
 
@@ -47,35 +48,35 @@ def _local(data_items, output_file, title = None, **kwargs):
         axes[1][-1].scatter(
             df[~df.individual].parameter.apply(str),
             df[~df.individual].value*1000
-            )
+        )
     axes[1][-1].axhline(0., color='gray')
     axes[1][-1].grid(axis='x', alpha='0.5')
     axes[1][-1].set_title('Structure Constants')
 
     fig.legend(
-        title = title,
-        loc = 'lower left',
-        bbox_to_anchor = (0.75, 0.6)
+        title=title,
+        loc='lower left',
+        bbox_to_anchor=(0.75, 0.6)
     )
     fig.savefig(output_file)
     plt.clear()
 
 
-def _global(data_items, output_file, title = None, which='hps', **kwargs):
+def _global(data_items, output_file, title=None, which='hps', **kwargs):
     """the global coordinate system is plottined in a 3x2 grid
     where the first column is position and the second column is
     euler angles. The rows go through x, y, z."""
 
     import matplotlib.pyplot as plt
     fig, axes = plt.subplots(
-        nrows = 3,
-        ncols = 2,
-        sharex = 'col'
+        nrows=3,
+        ncols=2,
+        sharex='col'
     )
-    fig.set_size_inches(17,8)
+    fig.set_size_inches(17, 8)
 
-    for i_c, c in enumerate(['x','y','z']):
-        for i_tr, tr in enumerate([which,'theta']):
+    for i_c, c in enumerate(['x', 'y', 'z']):
+        for i_tr, tr in enumerate([which, 'theta']):
             # go through coordinates down columns and
             # and position/rotation across rows
             ax = axes[i_c][i_tr]
@@ -83,10 +84,10 @@ def _global(data_items, output_file, title = None, which='hps', **kwargs):
                 ax.scatter(
                     data.sensor,
                     data[f'{tr}{c}']*1000,
-                    label = name if i_c==0 and i_tr == 0 else '_no_legend'
+                    label=name if i_c == 0 and i_tr == 0 else '_no_legend'
                 )
             if i_tr == 0:
-                ax.set_ylabel(f'{c.upper()} [$\mu$m]')
+                ax.set_ylabel(f'{c.upper()} [$\\mu$m]')
             else:
                 ax.set_ylabel(f'$\\theta_{c}$ [mrad]')
             ax.axhline(0.0, color='gray')
@@ -107,9 +108,9 @@ def _global(data_items, output_file, title = None, which='hps', **kwargs):
                     rotation=90
                 )
     fig.legend(
-        title = title,
-        loc = 'lower center',
-        bbox_to_anchor = (0.5, 0.9)
+        title=title,
+        loc='lower center',
+        bbox_to_anchor=(0.5, 0.9)
     )
     fig.savefig(output_file, bbox_inches='tight')
     plt.close()

--- a/src/hps_align/detdump/plot/_table_fig.py
+++ b/src/hps_align/detdump/plot/_table_fig.py
@@ -1,0 +1,114 @@
+"""construct different kinds of figures with tables of subplots"""
+
+def _local(data_items, output_file, title = None, **kwargs):
+    """the local coordinate system is plotted in a 2x4 grid where
+    the top row is translations, the bottom row is rotations, and
+    the last entry in the bottom row is for structure constants"""
+
+    import matplotlib.pyplot as plt
+    fig, axes = plt.subplots(
+        nrows = 2,
+        ncols = 4,
+        gridspec_kw = dict(
+            wspace = 0.2,
+            hspace = 0.3,
+        )
+    )
+    fig.set_size_inches(17,8)
+
+    for tr, i_tr in [('t',1),('r',2)]:
+        for uvw, i_uvw in [('u',1),('v',2),('w',3)]:
+            ax = axes[i_tr-1][i_uvw-1]
+            for name, df in data_items:
+                sl = (df.t_r == i_tr)&(df.u_v_w == i_uvw)
+                ax.scatter(
+                    df[sl].parameter.apply(str),
+                    df[sl].value*1000,
+                    label = name if (i_tr == 1 and i_uvw == 1) else '_no_legend'
+                )
+            ax.set_xticks(
+                ax.get_xticks(),
+                ax.get_xticklabels(),
+                rotation=90,
+                fontsize='xx-small'
+            )
+            ax.grid(axis='x', alpha=0.5)
+            ax.axhline(0., color='gray')
+            ax.set_title(f'{tr}{uvw}')
+            if i_uvw == 1:
+                if i_tr == 1:
+                    ax.set_ylabel('$\mu m$')
+                else:
+                    ax.set_ylabel('mrad')
+
+    axes[0][-1].axis('off')
+
+    for name, df in data_items:
+        axes[1][-1].scatter(
+            df[~df.individual].parameter.apply(str),
+            df[~df.individual].value*1000
+            )
+    axes[1][-1].axhline(0., color='gray')
+    axes[1][-1].grid(axis='x', alpha='0.5')
+    axes[1][-1].set_title('Structure Constants')
+
+    fig.legend(
+        title = title,
+        loc = 'lower left',
+        bbox_to_anchor = (0.75, 0.6)
+    )
+    fig.savefig(output_file)
+    plt.clear()
+
+
+def _global(data_items, output_file, title = None, which='hps', **kwargs):
+    """the global coordinate system is plottined in a 3x2 grid
+    where the first column is position and the second column is
+    euler angles. The rows go through x, y, z."""
+
+    import matplotlib.pyplot as plt
+    fig, axes = plt.subplots(
+        nrows = 3,
+        ncols = 2,
+        sharex = 'col'
+    )
+    fig.set_size_inches(17,8)
+
+    for i_c, c in enumerate(['x','y','z']):
+        for i_tr, tr in enumerate([which,'theta']):
+            # go through coordinates down columns and
+            # and position/rotation across rows
+            ax = axes[i_c][i_tr]
+            for name, data in data_items:
+                ax.scatter(
+                    data.sensor,
+                    data[f'{tr}{c}']*1000,
+                    label = name if i_c==0 and i_tr == 0 else '_no_legend'
+                )
+            if i_tr == 0:
+                ax.set_ylabel(f'{c.upper()} [$\mu$m]')
+            else:
+                ax.set_ylabel(f'$\\theta_{c}$ [mrad]')
+            ax.axhline(0.0, color='gray')
+            ax.grid(axis='x')
+            if c == 'x':
+                if i_tr == 0:
+                    if tr == 'hps':
+                        ax.set_title('HPS Global Position')
+                    else:
+                        ax.set_title('SVT Global Position')
+                else:
+                    ax.set_title('Euler Angle\n$\\theta_x = atan(v_z, w_z)$, $\\theta_y = -asin(u_z)$, $\\theta_z = atan(u_y, u_x)$')
+            if c == 'z':
+                ax.set_xticks(
+                    ax.get_xticks(),
+                    ax.get_xticklabels(),
+                    rotation=90
+                )
+    fig.legend(
+        title = title,
+        loc = 'lower center',
+        bbox_to_anchor = (0.5, 0.9)
+    )
+    fig.savefig(output_file, bbox_inches='tight')
+    plt.close()

--- a/src/hps_align/detdump/plot/_table_fig.py
+++ b/src/hps_align/detdump/plot/_table_fig.py
@@ -39,11 +39,9 @@ def _local(data_items, output_file, title=None, **kwargs):
                     df[sl].value*1000,
                     label=name if (i_tr == 1 and i_uvw == 1) else '_no_legend'
                 )
-            ax.set_xticks(
-                ax.get_xticks(),
-                ax.get_xticklabels(),
-                rotation=90,
-                fontsize='xx-small'
+            ax.tick_params(
+                labelrotation=90,
+                labelsize='xx-small'
             )
             ax.grid(axis='x', alpha=0.5)
             ax.axhline(0., color='gray')
@@ -132,10 +130,8 @@ def _global(data_items, output_file, title=None, position='hps', angle_title='An
                 else:
                     ax.set_title(angle_title)
             if c == 'z':
-                ax.set_xticks(
-                    ax.get_xticks(),
-                    ax.get_xticklabels(),
-                    rotation=90
+                ax.tick_params(
+                    labelrotation=90
                 )
     fig.legend(
         title=title,

--- a/src/hps_align/detdump/plot/_table_fig.py
+++ b/src/hps_align/detdump/plot/_table_fig.py
@@ -74,7 +74,7 @@ def _local(data_items, output_file, title=None, **kwargs):
     plt.clear()
 
 
-def _global(data_items, output_file, title=None, position='hps', angle_title='Angles', **kwargs):
+def _global(data_items, output_file, title=None, position='hps', angle_title='Angles', ref_line=0., **kwargs):
     """the global coordinate system is plottined in a 3x2 grid
     where the first column is position and the second column is
     euler angles. The rows go through x, y, z.
@@ -91,6 +91,8 @@ def _global(data_items, output_file, title=None, position='hps', angle_title='An
         which positional coordinates to use. Default is 'hps'.
     angle_title: str, optional
         title to have above the angle columns, useful for defining what angles are being plotted
+    ref_line: float, optional
+        where to draw a horizontal reference line, use None to disable drawing
     **kwargs: dict, optional
         the rest of the keyword arguments are absorbed but then ignored
     """
@@ -118,7 +120,8 @@ def _global(data_items, output_file, title=None, position='hps', angle_title='An
                 ax.set_ylabel(f'{c.upper()} [$\\mu$m]')
             else:
                 ax.set_ylabel(f'$\\theta_{c}$ [mrad]')
-            ax.axhline(0.0, color='gray')
+            if ref_line is not None:
+                ax.axhline(ref_line, color='gray')
             ax.grid(axis='x')
             if c == 'x':
                 if i_tr == 0:

--- a/src/hps_align/detdump/plot/_table_fig.py
+++ b/src/hps_align/detdump/plot/_table_fig.py
@@ -100,7 +100,6 @@ def _global(data_items, output_file, title=None, which='hps', **kwargs):
                         ax.set_title('SVT Global Position')
                 else:
                     ax.set_title('Axis Angles\n$\\theta_x = acos(v_x)$, $\\theta_y = acos(u_y)$, $\\theta_z = acos(w_z)$')
-                    #ax.set_title('Euler Angle\n$\\theta_x = atan(v_z, w_z)$, $\\theta_y = -asin(u_z)$, $\\theta_z = atan(u_y, u_x)$')
             if c == 'z':
                 ax.set_xticks(
                     ax.get_xticks(),


### PR DESCRIPTION
- do some global plotting using 2016 detectors as reference
- add some doc for cli
- add mpl and pandas now being used in detdump plot
- move table figures into their own module for isolation sake

Started up the framework necessary for plotting the JSON/CSV data dumped by detdump. Putting it in its own submodule for now with separate files for different tasks (e.g. loading and plotting). Added matplotlib and pandas to the setup.py so they will be installed for users who `pip install`.

**Have not tested this outside of the hps-env container environment or for a non-2016 detector**

## To Do
- [x] pycodestyle fixes
- [x] document functions with docstrings and comments
- [x] get plotting working for other years as well
- [x] can we do a cross-year comparison of sensor positions and orientations?
    - if this is too complicated, it might be best to put it in its own PR
    - [x] 2019-2021 comparisons are easy since they have the same sensor set
    - [x] 2016-vs-19/21 needs additional mapping of sensor names
